### PR TITLE
add golang and protoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
-FROM grpc/go:latest
+FROM golang:bullseye
 
-RUN rm -rf /usr/local/go && curl -sL "https://storage.googleapis.com/golang/$(curl -s https://golang.org/VERSION?m=text).linux-amd64.tar.gz" | tar xz -C /usr/local
+RUN apt-get update && \
+	apt-get install -y protobuf-compiler && \
+	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
ベースで使っていたgrpc/goでバンドルされているgrpc-goが古く、更新が止まっているため、必要なものだけ改めて入れるようにしています。

grpc-go自体はgo installするパターンが多いため、バイナリ自体不要。